### PR TITLE
Fix issue with plugin failing due to nodejs not being installed

### DIFF
--- a/src/utils/compress.ts
+++ b/src/utils/compress.ts
@@ -1,10 +1,12 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
+import { resolveTaskRunnerCommand } from './resolve-task-runner-command';
 
 export function compressCSS(inputFile: string, outputFile: string): Promise<void> {
-	return new Promise((resolve, reject) => {
+	return new Promise(async (resolve, reject) => {
+		const taskRunner = await resolveTaskRunnerCommand();
 		exec(
-			`npx postcss ${inputFile} --use cssnano --no-map -o ${outputFile}`,
+			`${taskRunner} postcss ${inputFile} --use cssnano --no-map -o ${outputFile}`,
 			(error, stdout, stderr) => {
 				if (error) {
 					console.error(`[iconify] Error compressing CSS: ${error.message}`);

--- a/src/utils/resolve-task-runner-command.ts
+++ b/src/utils/resolve-task-runner-command.ts
@@ -1,0 +1,45 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import { platform } from "node:os";
+
+type RuntimePlatformName = 'bun' | 'deno' | 'node';
+
+const execAsync = promisify(exec);
+
+async function detectRuntimeExecutable(): Promise<RuntimePlatformName> {
+	try {
+		await execAsync("bun --version");
+		return "bun";
+	} catch {
+	}
+
+	try {
+		await execAsync("deno --version");
+		return "deno";
+	} catch {
+	}
+
+	try {
+		await execAsync("node --version");
+		return "node";
+	} catch {
+	}
+
+	console.error("[iconify] Could not detect runtime executable");
+	// TODO: should we design an error code system or always return 1 on error?
+	process.exit(1);
+}
+
+const runtimeToTaskRunnerCommandMap: Record<RuntimePlatformName, string> = {
+	"node": "npx",
+	"bun": "bunx",
+	// \x7F is ASCII for DEL
+	// we need it to glue together the `deno task npm:` part
+	// with the npm script that is going to be run
+	"deno": "deno task npm:\x7F",
+};
+
+export async function resolveTaskRunnerCommand() {
+	const platformName = await detectRuntimeExecutable()
+	return runtimeToTaskRunnerCommandMap[platformName];
+}


### PR DESCRIPTION
**the problem**

i do not use node, and don't have node executable. due to the `compress` script relying on `npm` being present — the script fails like so:

```
pathscale-ui ) bun run build
$ rslib build && bun scripts/copy-css.js
  Rslib v0.9.1

[iconify] Starting icon generation...
[iconify] Skipping generated icons file: src/styles/icons/generated-icons.css
[iconify] Debug info for icon sets:
[iconify] Set mdi-light found in 6 places
[iconify]   - File: src/components/calendar/Calendar.tsx
[iconify]     Pattern: /icon-\[([\w-]+)--([^\]]+)\]/g
[iconify]     Matches: mdi-light--chevron-left, icon-[mdi-light--chevron-left]
[iconify]   - File: src/components/calendar/Calendar.tsx
[iconify]     Pattern: /icon-\[([\w-]+)--([^\]]+)\]/g
[iconify]     Matches: mdi-light--chevron-right, icon-[mdi-light--chevron-right]
[iconify]   - File: src/components/calendar/Calendar.tsx
[iconify]     Pattern: /name="icon-\[([\w-]+)--([^\]]+)\]"/g
[iconify]     Matches: mdi-light--chevron-left, icon-[mdi-light--chevron-left]
[iconify]   - File: src/components/calendar/Calendar.tsx
[iconify]     Pattern: /name="icon-\[([\w-]+)--([^\]]+)\]"/g
[iconify]     Matches: mdi-light--chevron-right, icon-[mdi-light--chevron-right]
[iconify]   - File: src/components/calendar/Calendar.tsx
[iconify]     Pattern: /"icon-\[([\w-]+)--([^\]]+)\]"/g
[iconify]     Matches: mdi-light--chevron-left, icon-[mdi-light--chevron-left]
[iconify] Found 4 unique icons in code
[iconify] Used icon sets: mdi-light
[iconify] Set mdi-light uses 2 icons
[iconify] Found 198 icon sets in @iconify/json
[iconify] Processed icon set mdi-light: 2 icons
[iconify] Total: processed 2 icons from 1 sets
[iconify] CSS file with icons saved in src/styles/icons/generated-icons.css
[iconify] Error compressing CSS: Command failed: npx postcss src/styles/icons/generated-icons.css --use cssnano --no-map -o src/styles/icons/generated-icons.min.css
/bin/sh: npx: command not found

error   Failed to build.
error   Command failed: npx postcss src/styles/icons/generated-icons.css --use cssnano --no-map -o src/styles/icons/generated-icons.min.css
/bin/sh: npx: command not found

    at genericNodeError (node:child_process:944:22)
    at exitHandler (node:child_process:102:28)
    at emit (node:events:92:22)
    at #maybeClose (node:child_process:735:16)
    at #handleOnExit (node:child_process:514:72)
    at processTicksAndRejections (native:7:39)
error: script "build" exited with code 1

```

key point is `/bin/sh: npx: command not found`

**the solution**

introduce a helper function to detect which js runtime is present in the following preference: bun, deno, node

if neither is present — end the process with error code (1 for now)