### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
 		"prepublishOnly": "npm run build"
 	},
 	"homepage": "https://github.com/pathscale/iconify-preload",
+	"bugs": {
+		"url": "https://github.com/pathscale/iconify-preload/issues"
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/pathscale/iconify-preload.git"


### PR DESCRIPTION
## Summary
- add `bugs.url` metadata pointing to the GitHub issue tracker
- keep existing homepage, repository, and license metadata unchanged

## Validation
- `node -e "const p=require('./package.json'); if(!p.bugs || p.bugs.url !== 'https://github.com/pathscale/iconify-preload/issues') throw new Error('bad bugs url'); console.log(JSON.stringify({name:p.name, homepage:p.homepage, bugs:p.bugs, repository:p.repository, license:p.license}, null, 2));"`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`